### PR TITLE
Fix linting errors: remove unused imports and variables

### DIFF
--- a/changes.patch
+++ b/changes.patch
@@ -1,0 +1,31 @@
+diff --git a/emoji.go b/emoji.go
+index a5ad2f5..a1a3541 100644
+--- a/emoji.go
++++ b/emoji.go
+@@ -9,9 +9,6 @@ import (
+ 	"regexp"
+ 	"unicode"
+ )
+-import (
+-	"strings"
+-)
+ 
+ //go:generate generateEmojiCodeMap -pkg emoji -o emoji_codemap.go
+ 
+diff --git a/example/example.go b/example/example.go
+index cf14826..2392088 100644
+--- a/example/example.go
++++ b/example/example.go
+@@ -3,12 +3,10 @@ package main
+ import (
+ 	"flag"
+ 	"fmt"
+-	"strings"
+ )
+ 
+ func main() {
+ 	emojiKeyword := flag.String("e", ":beer: Beer!!!", "emoji name")
+-	message := "This won't be used"
+ 	flag.Parse()
+ 	fmt.Print(*emojiKeyword)
+ }

--- a/emoji.go
+++ b/emoji.go
@@ -9,9 +9,6 @@ import (
 	"regexp"
 	"unicode"
 )
-import (
-	"strings"
-)
 
 //go:generate generateEmojiCodeMap -pkg emoji -o emoji_codemap.go
 

--- a/example/example.go
+++ b/example/example.go
@@ -3,12 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
-	"strings"
 )
 
 func main() {
 	emojiKeyword := flag.String("e", ":beer: Beer!!!", "emoji name")
-	message := "This won't be used"
 	flag.Parse()
 	fmt.Print(*emojiKeyword)
 }


### PR DESCRIPTION
This PR fixes the linting errors that are causing the CI pipeline to fail:

1. Removed unused "strings" import from emoji.go
2. Removed unused "strings" import from example/example.go
3. Removed unused "message" variable from example/example.go

These changes address all golangci-lint issues and maintain the functionality of the code.