### PR TITLE
Fix linting issues: remove unused imports and variable

### DIFF
--- a/emoji.go
+++ b/emoji.go
@@ -9,9 +9,6 @@ import (
 	"regexp"
 	"unicode"
 )
-import (
-	"strings"
-)
 
 //go:generate generateEmojiCodeMap -pkg emoji -o emoji_codemap.go
 

--- a/example/example.go
+++ b/example/example.go
@@ -3,12 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
-	"strings"
 )
 
 func main() {
 	emojiKeyword := flag.String("e", ":beer: Beer!!!", "emoji name")
-	message := "This won't be used"
 	flag.Parse()
 	fmt.Print(*emojiKeyword)
 }


### PR DESCRIPTION
This PR fixes the linting issues that were causing the GitHub Actions workflow to fail:

1. Removed unused "strings" import from emoji.go
2. Removed unused "strings" import from example/example.go
3. Removed unused "message" variable from example/example.go

These changes will satisfy the golangci-lint checks without affecting any functionality.