### PR TITLE
Fix linting errors: Remove unused imports and variables

### DIFF
--- a/emoji.go
+++ b/emoji.go
@@ -9,9 +9,6 @@ import (
 	"regexp"
 	"unicode"
 )
-import (
-	"strings"
-)
 
 //go:generate generateEmojiCodeMap -pkg emoji -o emoji_codemap.go
 

--- a/example/example.go
+++ b/example/example.go
@@ -3,12 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
-	"strings"
 )
 
 func main() {
 	emojiKeyword := flag.String("e", ":beer: Beer!!!", "emoji name")
-	message := "This won't be used"
 	flag.Parse()
 	fmt.Print(*emojiKeyword)
 }


### PR DESCRIPTION
This PR fixes the linting errors that were causing the workflow to fail by:

1. Removing the unused `strings` import from `emoji.go`
2. Removing the unused `strings` import from `example/example.go`
3. Removing the unused `message` variable from `example/example.go`

These changes resolve all the issues identified by golangci-lint without changing any functionality.