### PR TITLE
Fix linting errors: Remove unused imports and variables

### DIFF
--- a/emoji.go
+++ b/emoji.go
@@ -9,9 +9,6 @@ import (
 	"regexp"
 	"unicode"
 )
-import (
-	"strings"
-)
 
 //go:generate generateEmojiCodeMap -pkg emoji -o emoji_codemap.go
 

--- a/example/example.go
+++ b/example/example.go
@@ -3,12 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
-	"strings"
 )
 
 func main() {
 	emojiKeyword := flag.String("e", ":beer: Beer!!!", "emoji name")
-	message := "This won't be used"
 	flag.Parse()
 	fmt.Print(*emojiKeyword)
 }


### PR DESCRIPTION
## Description
This PR fixes the linting errors that were causing the GitHub Actions workflow to fail by:

1. Removing unused imports:
   - `strings` package from `emoji.go`
   - `strings` package from `example/example.go`

2. Removing unused variables:
   - `message` variable from `example/example.go`

These changes should resolve all the linting errors detected by `golangci-lint` in the CI pipeline.

## Related Issues
Fixes the failing workflow run: https://github.com/CloudSmith-Agent-Benchmark/emoji/actions/runs/15289825942