### PR TITLE
Fix linting issues: Remove unused imports and variable

### DIFF
--- a/emoji.go
+++ b/emoji.go
@@ -9,9 +9,6 @@ import (
 	"regexp"
 	"unicode"
 )
-import (
-	"strings"
-)
 
 //go:generate generateEmojiCodeMap -pkg emoji -o emoji_codemap.go
 

--- a/example/example.go
+++ b/example/example.go
@@ -3,12 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
-	"strings"
 )
 
 func main() {
 	emojiKeyword := flag.String("e", ":beer: Beer!!!", "emoji name")
-	message := "This won't be used"
 	flag.Parse()
 	fmt.Print(*emojiKeyword)
 }


### PR DESCRIPTION
This PR resolves the golangci-lint failures identified in the CI workflow.

Changes:
1. Remove unused "strings" import from emoji.go
2. Remove unused "strings" import from example/example.go
3. Remove unused "message" variable declaration from example/example.go

These changes ensure the code complies with Go's code quality standards, which require that all imported packages and declared variables be used.