### PR TITLE
Fix linting errors: Remove unused imports and variables

### DIFF
--- a/emoji.go
+++ b/emoji.go
@@ -9,9 +9,6 @@ import (
 	"regexp"
 	"unicode"
 )
-import (
-	"strings"
-)
 
 //go:generate generateEmojiCodeMap -pkg emoji -o emoji_codemap.go
 

--- a/example/example.go
+++ b/example/example.go
@@ -3,12 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
-	"strings"
 )
 
 func main() {
 	emojiKeyword := flag.String("e", ":beer: Beer!!!", "emoji name")
-	message := "This won't be used"
 	flag.Parse()
 	fmt.Print(*emojiKeyword)
 }


### PR DESCRIPTION
This PR fixes the linting errors detected by golangci-lint in the CI workflow:

1. Removed unused "strings" import from emoji.go
2. Removed unused "strings" import from example/example.go
3. Removed unused "message" variable from example/example.go

These changes address the following errors reported by the linter:
- example/example.go:6:2: "strings" imported and not used
- example/example.go:11:2: declared and not used: message (typecheck)
- ./emoji.go:13:2: "strings" imported and not used (typecheck)

The changes are purely code cleanup and don't affect any functionality.